### PR TITLE
Function access-path->sql ported to querysets

### DIFF
--- a/src/queryset.lisp
+++ b/src/queryset.lisp
@@ -291,6 +291,14 @@ holds field name."
     (setf (queryset-fields qs)
           (append (queryset-fields qs) (list field)))))
 
+(defun add-join (queryset mode qs alias relation)
+  (setf (queryset-joins queryset)
+        (append (queryset-joins queryset) (list (make-join mode qs alias relation)))))
+
+(defun add-filter (queryset relation)
+  (setf (queryset-where queryset)
+        (append (queryset-where queryset) (list relation))))
+
 
 
 (defmacro select (model &rest clauses)

--- a/src/queryset.lisp
+++ b/src/queryset.lisp
@@ -284,7 +284,8 @@ holds field name."
        :do
        (let ((join (find-join qs table-name)))
          (if join
-             (unless (find-qs-attribute field-name (join-queryset join))
+             (unless (or (stringp (join-queryset join))
+                         (find-qs-attribute field-name (join-queryset join)))
                (error "Attribute ~A.~A not found." table-name field-name))
              (add-simple-join qs table-name))))
     (setf (queryset-fields qs)

--- a/test/test-queryset.lisp
+++ b/test/test-queryset.lisp
@@ -13,18 +13,6 @@
   create-queryset
   (let ((queryset (make-instance 'secsrv.queryset::<queryset>
                    :main-table "article"))
-        (journal-join (secsrv.queryset::make-join
-                        secsrv.queryset::+left-join+
-                        "journal" ;; table
-                        "T1" ;; alias
-                        (secsrv.queryset::make-relation "T0.f_journal_id" "=" "T1.f_journal_id")))
-        (collection-join (secsrv.queryset::make-join
-                           secsrv.queryset::+join+
-                           (secsrv.queryset::make-default-queryset "collection")
-                           "T2" ;; alias
-                           (secsrv.queryset::make-relation "T0.f_collection_id" "=" "T2.f_collection_id")))
-        (article-id-filter (secsrv.queryset::make-relation "T0.f_article_id" "=" "211459"))
-        (collection-id-filter (secsrv.queryset::make-relation "T2.f_collection_id" "IS NOT" "NULL"))
         (expected-query (concatenate-newline
                           "SELECT f_article_id AS id"
                           "FROM article AS T0"
@@ -34,8 +22,16 @@
                           "WHERE T0.f_article_id = 211459"
                           "AND T2.f_collection_id IS NOT NULL")))
     (secsrv.queryset::add-select-expression queryset "f_article_id" "id")
-    (setf (secsrv.queryset::queryset-joins queryset)
-          (append (secsrv.queryset::queryset-joins queryset) `(,journal-join ,collection-join)))
-    (setf (secsrv.queryset::queryset-where queryset)
-          (append (secsrv.queryset::queryset-where queryset) `(,article-id-filter ,collection-id-filter)))
+    (secsrv.queryset::add-join queryset
+                               secsrv.queryset::+left-join+
+                               "journal" ;; table
+                               "T1" ;; alias
+                               (secsrv.queryset::make-relation "T0.f_journal_id" "=" "T1.f_journal_id"))
+    (secsrv.queryset::add-join queryset
+                               secsrv.queryset::+join+
+                               (secsrv.queryset::make-default-queryset "collection")
+                               "T2" ;; alias
+                               (secsrv.queryset::make-relation "T0.f_collection_id" "=" "T2.f_collection_id"))
+    (secsrv.queryset::add-filter queryset (secsrv.queryset::make-relation "T0.f_article_id" "=" "211459"))
+    (secsrv.queryset::add-filter queryset (secsrv.queryset::make-relation "T2.f_collection_id" "IS NOT" "NULL"))
     (ensure-same expected-query (secsrv.queryset::sql<-queryset queryset))))


### PR DESCRIPTION
The generated SQL is the same as before, just it is generated using `<queryset>` class and not manually.

Example (taken from tests):
- Before:
    ```sql
    SELECT T2.bitem_value FROM a T0  JOIN b T1 ON (T1.a_id=T0.a_id)  JOIN bitem T2 ON (T2.b_id=T1.b_id)  WHERE  T0.a_id = 3
    ```
- After:
    ```sql
    SELECT T2.bitem_value AS bitem_value
    FROM a AS T0
    JOIN b T1 ON (T1.a_id = T0.a_id)
    JOIN bitem T2 ON (T2.b_id = T1.b_id)
    WHERE T0.a_id = 3
    ```

To make it easier to write code, helper functions `add-join` and `add-filter` were added.

**Warning**: Only primitive constraints are supported so far. For complex constraints `ap-constraint->sql` function should be called on first and second arguments before passing them to queryset. That can be done later.